### PR TITLE
Build files are now automaticaly deleted by default

### DIFF
--- a/src/main/java/hudson/plugins/antexec/AntExec.java
+++ b/src/main/java/hudson/plugins/antexec/AntExec.java
@@ -281,7 +281,7 @@ public class AntExec extends Builder {
             } finally {
                 aca.forceEol();
                 //After the ant script has been executed, we delete the build.xml.
-                //The plugin is a way to run an Ant Script from a small source code, we shoudn't keep the build.xml
+                //The plugin is a way to run an Ant Script from a small source code, we shoudn't keep the antexec_build.xml
                 if (keepBuildfile == null || !keepBuildfile) {
                     boolean deleteResponse = buildFile.delete();
                     if (!deleteResponse) listener.getLogger().println("The temporary Ant Build Script coudn't be deleted");


### PR DESCRIPTION
Build files are now automaticaly deleted by default so you need to update job configuration if you want to keep them.
