### PR TITLE
feat: upgrade to Jenkins LTS Core 2.462.3 for Java 11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.452</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+        <jenkins.baseline>2.462</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     </properties>
     <name>AntExec</name>
     <description>Adds new build step for running directly written Apache Ant code</description>


### PR DESCRIPTION
Hello `antexec` developers! :wave:

This automated pull request was generated by the [Jenkins Plugin Modernizer](https://github.com/jenkins-infra/plugin-modernizer-tool). We’ve applied an essential modernization recipe to your plugin:

<details aria-label="Recipe details: Upgrade to Jenkins LTS Core 2.462.3">
   <summary>Upgrade to Jenkins LTS Core 2.462.3</summary>
   <p><em>io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion</em></p>
   <blockquote>Upgrade to the latest LTS core version supporting Java 11.</blockquote>
</details>

### Importance of this Upgrade:

#### Transitional Step to Java 17
Upgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.

#### Enhancements and Security
By moving to this LTS version, we benefit from the latest improvements in performance and security that are foundational to Java 11. This prepares the groundwork for a smoother transition to Java 17 by ensuring our dependencies are up-to-date and secure.

#### Long-Term Support
The LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.

Embracing these incremental changes not only aligns our development environment with current standards but also strategically positions us for future advancement. Your feedback and testing are appreciated as we aim for a seamless adjustment period.


